### PR TITLE
Can use extend-postcss alias as extend rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ npm install postcss-extend --save-dev
     - [Extending something inside @media (on the outside looking in)](https://github.com/travco/postcss-extend#extending-something-inside-media-on-the-outside-looking-in)
     - [Extending something in an @media while inside an @media](https://github.com/travco/postcss-extend#extending-something-in-an-media-while-inside-an-media)
 - [Chaining `@extend`s, or Extension-Recursion](https://github.com/travco/postcss-extend#chaining-extends-or-extension-recursion)
+- [Getting It Working with SASS](https://github.com/travco/postcss-extend#getting-it-working-with-sass)
 
 ### Defining Placeholders
 
@@ -365,6 +366,18 @@ console.log(outputCss);
 ```
 
 Or take advantage of [any of the myriad of other ways to consume PostCSS](https://github.com/postcss/postcss#usage), and follow the plugin instructions they provide.
+
+## Getting it Working with SASS:
+If you need to run a SASS pre-processor, there is an alias called `@extend-postcss`:
+```css
+.alpha {
+  color: red;
+}
+
+.beta {
+  @extend-postcss .alpha;
+}
+```
 
 ## Quirks
 As with any piece of code, it's got a few quirks. Behaviors that are not intended, and not enforced, may disappear (or be forcibly altered) with the next release, so it's useful to be aware of them.

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = postcss.plugin('postcss-extend', function extend() {
 
   return function(css, result) {
     var definingAtRules = ['define-placeholder', 'define-extend', 'extend-define'];
-    var extendingAtRules = ['extend'];
+    var extendingAtRules = ['extend', 'extend-postcss'];
     var recurseStack = [];
     var isAntiPatternCSS = false;
 

--- a/test/index.js
+++ b/test/index.js
@@ -287,6 +287,15 @@ test('accepts alternative at-rules', function(t) {
   t.end();
 });
 
+test('accepts alternative extend aliases', function(t) {
+  var standard = p('@define-placeholder bar { background: pink; } .foo { @extend-postcss bar; }');
+  t.equal(
+    p('@define-extend bar { background: pink; } .foo { @extend bar; }'),
+    standard
+  );
+  t.end();
+});
+
 test('eliminates unused definition', function(t) {
   t.equal(p('@define-placeholder foo { background: pink; }'), '');
   t.end();


### PR DESCRIPTION
@travco  @jonathantneal @davidtheclark 

### Problem:
Some of us still use **SASS** from legacy code bases that force us to compile **SCSS** first. Using something like this:
``` css
@add-mixin somethingThatGeneratesClasses;

.my-class {
 @extend .generatedClass;
}
```
will make the **SASS** compiler grab that extend rule before **PostCSS**.

#### Solution:
Allow use of an alias for the `@extend` rule, in this case, `@extend-postcss`.

As reference, `postcss-mixins` does it, as described in the README section [Migration from SASS](https://github.com/postcss/postcss-mixins#migration-from-sass).