### PR TITLE
feat: Add option to keep the placeholders

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,8 +13,9 @@
     "no-nested-ternary": 2,
     "no-use-before-define": [2, "nofunc"],
     "quotes": [2, "single"],
-    "space-after-function-name": [2, "never"],
-    "space-after-keywords": [2, "always"],
+    "space-before-function-paren": [2, "never"],
+    "space-after-keywords": "off",
+    "keyword-spacing": [2, {"before": true, "after": true}],
     "space-before-blocks": [2, "always"],
     "space-in-parens": [2, "never"],
     "space-unary-ops": 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
-  - "0.12"
-  - "iojs"
+  - "8"
 
 notifications:
   email:

--- a/index.js
+++ b/index.js
@@ -3,8 +3,11 @@
 var postcss = require('postcss');
 // /*DEBUG*/var appendout = require('fs').appendFileSync;
 
-module.exports = postcss.plugin('postcss-extend', function extend() {
-
+module.exports = postcss.plugin('postcss-extend', function extend(opts) {
+  opts = opts || {};
+  
+  var keepPlaceholders = opts.keepPlaceholders;
+  
   return function(css, result) {
     var definingAtRules = ['define-placeholder', 'define-extend', 'extend-define'];
     var extendingAtRules = ['extend'];
@@ -33,7 +36,7 @@ module.exports = postcss.plugin('postcss-extend', function extend() {
           } else {
             selectorAccumulator.push(tgtSaved[i]);
           }
-        } else if (tgtSaved.length === 1) {
+        } else if (!keepPlaceholders && tgtSaved.length === 1) {
           targetNode.remove();
         // /*DEBUG*/} else {
           // /*DEBUG*/appendout('./test/debugout.txt', '\nSifted out placeholder/silent ' + tgtSaved[i]);
@@ -342,7 +345,7 @@ module.exports = postcss.plugin('postcss-extend', function extend() {
 
     function findUnresolvedExtendChild(nodeOrigin) {
       var foundNode = {};
-      var foundBool = nodeOrigin.some(function (node) {
+      var foundBool = nodeOrigin.some(function(node) {
         if (node.type === 'atrule' && extendingAtRules.indexOf(node.name) !== -1) {
           foundNode = node;
           return true;
@@ -410,7 +413,7 @@ module.exports = postcss.plugin('postcss-extend', function extend() {
 
     function findBrotherSubClass(nodeOrigin, tgtSub) {
       var foundNode = {};
-      var foundBool = nodeOrigin.parent.some(function (node) {
+      var foundBool = nodeOrigin.parent.some(function(node) {
         if (node.selectors) {
           var seldiff = node.selectors;
           var selectorAccumulator = nodeOrigin.selectors;

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "postcss": "^5.0.4"
   },
   "devDependencies": {
-    "eslint": "0.18.0",
+    "eslint": "5.12.0",
     "tape": "4.0.0"
   }
 }


### PR DESCRIPTION
### Purpose of this PR

- [X] Feature

### Necessity

- I have a project that is a css theme project, with font-sizes, font-style, etc.
- Using this postcss plugin it was possible to do things like this:

typography file
```js
.font-xs {
    @extend %font-size-xs;
}
```

placeholders file
```js
%font-size-xs{
    @add-mixin fontSizeXs;
}
```

- With this plugin it turns the files into this:

typography file
```js
.font-xs {
    font-size: 1.2rem;
    text-transform: none;
    line-height: 1.8 ;
    letter-spacing: normal;
}
```

placeholders file
```js
// turns empty
```

- What I wanted is to have the placeholders to reuse in other projects, because as this is a separate package, when bundled the placeholders can't be used in other projects
- So this PR adds the option to keep the placeholders and have this final result:

Placeholders file
```js
%font-size-xs {
    font-size: 1.2rem;
    text-transform: none;
    line-height: 1.8 ;
    letter-spacing: normal;
}
```

- Like this I can have new classes in other projects that just extend the %placeholders created previously

### Changes

- Introduces opts in the postcss config
- with opts `keepPlaceholders` will not remove the placeholders definition

### How it works

```js
postcssExtend({
    keepPlaceholders: true,
}),
```

- With this option the postcss-extend keeps the placeholders definition

### Review
- Thanks for the help


